### PR TITLE
use `process.execPath` instead of `'node'`

### DIFF
--- a/manager.js
+++ b/manager.js
@@ -108,7 +108,7 @@ if (command === 'create') {
 } else if (command === 'list') {
     // List all the running holesail connections
     // Need to spwan or else PM2 will display full black and white
-  const child = spawn('node', [pm2Binary, 'list'], {
+  const child = spawn(process.execPath, [pm2Binary, 'list'], {
     shell: true,
     stdio: 'inherit',
     env: { ...process.env, FORCE_COLOR: 'true' } // Force color output


### PR DESCRIPTION
I am working on making a nix flake for holesail, and nix is very precise about the packages that it uses. For that reason, simply using `'node'` to spawn a new process is not sufficient. Nix needs to know the exact path of the exectuable.
This modification makes it work.
You can try out the flake [here](https://github.com/gudnuf/holesail-nix/tree/main). 