### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ npm i holesail -g
 To start a local Holesail Server, use the following command:
 
 ```
-holesail --live port
+holesail --live <port>
 ```
 Replace `port` with the desired port number you want to expose to the network.
 


### PR DESCRIPTION
CLI convention for arguments: `<mandatory>` `[optional]`
Otherwise, it feels that `--live port` is a hardcoded command.