### PR TITLE
Fix: Convert url to string in urlParser to handle non-string inputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ class Holesail extends ReadyResource {
   }
 
   static urlParser (url) {
+    url = String(url || '');
     const protocol = 'hs://'
     let key
     let secure


### PR DESCRIPTION
This prevents TypeError when substring is called on numbers or other non-strings, such as keys passed as integers.